### PR TITLE
BAC-3553: Add exceptions for global variables

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -4,6 +4,11 @@ module.exports = {
     "es6": true,
     "mocha": true
   },
+  "globals": {
+    "assert": false,
+    "expect": false,
+    "should": false
+  },
   "rules": {
     "accessor-pairs": "off",
     "array-callback-return": "error",


### PR DESCRIPTION
In order to avoid defining assertion libraries in every single test file it's better to have them added as exception in the ruleset. That way errors/warns like "error 'expect' is not defined no-undef" will be handled.