### PR TITLE
BACK-3680: Turn off rule that expects class methods to use 'this'.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,6 @@ module.exports = {
   ].map(require.resolve),
   parserOptions: {
     ecmaVersion: 2017,
-    sourceType: 'module',
-    ecmaFeatures: {
-      experimentalObjectRestSpread: true,
-    },
+    sourceType: 'module'
   }
 };

--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -17,12 +17,7 @@ module.exports = {
       "off",
       11
     ],
-    "class-methods-use-this": [
-      "error",
-      {
-        "exceptMethods": []
-      }
-    ],
+    "class-methods-use-this": "off",
     "consistent-return": "warn",
     "curly": [
       "error",
@@ -859,8 +854,7 @@ module.exports = {
     "ecmaFeatures": {
       "globalReturn": true,
       "generators": false,
-      "objectLiteralDuplicateProperties": false,
-      "experimentalObjectRestSpread": true
+      "objectLiteralDuplicateProperties": false
     },
     "ecmaVersion": 2017,
     "sourceType": "module"


### PR DESCRIPTION
Also remove deprecated flag.