### PR TITLE
Demote no-param-reassign to warning

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -112,7 +112,7 @@ module.exports = {
     "no-new-wrappers": "error",
     "no-octal": "error",
     "no-octal-escape": "error",
-    "no-param-reassign": "error",
+    "no-param-reassign": "warn",
     "no-proto": "error",
     "no-redeclare": "error",
     "no-restricted-properties": [


### PR DESCRIPTION
The eslint rule `no-param-reassign` is currently set to "error". This rule is very hard to maintain and leads to ugly code such as 

```javascript
function someFunc (id, _options) {
  const options = _options || { timeout: 1000 };
}
```

There are more extreme examples in our codebase, this one is almost acceptable. I think the performance benefit (measured by me at between 1 and 4%) is negligible and the cases where this rule leads to better code are fewer and less pronounced than the cases where it leads to worse code. This is why I think it's better suited as a warning - one can pay be notified, but choose to keep the code they wrote, knowingly.

