### PR TITLE
allow 'use strict'

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -848,7 +848,7 @@ module.exports = {
     "import/no-webpack-loader-syntax": "error",
     "import/no-unassigned-import": "off",
     "import/no-named-default": "error",
-    "strict": "error"
+    "strict": "off"
   },
   "parserOptions": {
     "ecmaFeatures": {


### PR DESCRIPTION
allow `'use strict';` at the top of the file.  It does some checks not covered by linting, and checks at parse time, not just during the linting step.  It never hurts to have one more check.