### PR TITLE
allow space in parens

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -605,7 +605,7 @@ module.exports = {
       }
     ],
     "space-in-parens": [
-      "error",
+      "off",
       "never"
     ],
     "space-infix-ops": "error",


### PR DESCRIPTION
allow spaces inside parentheses.  Realistically, this is not a problem our codebase tends to have, and human code reviews are perfectly find to catch and fix it.  Permitting spaces inside parentheses does allow formatting code for legibility and clarity, however; e.g.:
```
checksum =
        ((value >> 24) & 0xFF) ^
        ((value >> 16) & 0xFF) ^
        ((value >>  8) & 0xFF) ^
        ((value      ) & 0xFF);
```