### PR TITLE
raise max-len to 160

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -382,7 +382,7 @@ module.exports = {
     ],
     "max-len": [
       "warn",
-      120,
+      160,
       4
     ],
     "max-lines": [


### PR DESCRIPTION
max-len line length of 120 is fairly short, especially for older components written with longer limits.  Since this is just a warning anyway, raise it to 160.