### PR TITLE
allow multiple spaces on lines

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -105,7 +105,7 @@ module.exports = {
         "detectObjects": false
       }
     ],
-    "no-multi-spaces": "error",
+    "no-multi-spaces": "off",
     "no-multi-str": "error",
     "no-new": "error",
     "no-new-func": "error",


### PR DESCRIPTION
this rule does more harm than good:  it addresses a problem we don't have, but prevents layout techniques useful for better code clarity.  Continue to allow this usage, e.g.
```
  first      = 1;    // first value
  subsequent = 22;   // second value
  next       = 333;  // next value
  ultimate   = 4444; // last value
```