### PR TITLE
allow use-before-define for functions

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -666,7 +666,7 @@ module.exports = {
         "args": "after-used"
       }
     ],
-    "no-use-before-define": ["error", { "functions": false }],
+    "no-use-before-define": ["error", { "functions": true }],
     "arrow-body-style": [
       "warn",
       "as-needed"


### PR DESCRIPTION
this rule breaks the standard javascript semantics that functions are fully defined and usable everywhere in scope, and prevents the usual top-down implementation convention (main functions on top, helper functions below in the file).  The benefit of this rule is primarily for `var` definitions (`let` and `const` variables inherently cannot be used before defined), it is more harmful than helpful for function definitions.  Allow functions to be used everywhere in scope.