### PR TITLE
Allow object shorthand

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -719,7 +719,7 @@ module.exports = {
     "no-var": "error",
     "object-shorthand": [
       "error",
-      "always",
+      "consistent",
       {
         "ignoreConstructors": false,
         "avoidQuotes": true


### PR DESCRIPTION
The new object shorthand notation is a shorthand, not a replacement, and mandating its use in all cases can result in ugly, hard to read code.  It is much better to be consistent than to compulsorily always use this feature.

An example of the awkward compulsory mish-mash:
```
    const b = 2;
    const x = {
        a: 1,                     // cannot be abbreviated, must be in standard notation
        b,                        // mandatory abbreviation
        bTwo: b,                  // rename, cannot be abbreviated
        third() { return 3 },     // mandatory abbreviation, an unusual-looking function definition
        fourth: () => 4,          // cannot be abbreviated, standard notation
    }
```