### PR TITLE
make the semicolon optional before the closing brace on one-liner functions

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -577,7 +577,10 @@ module.exports = {
     "require-jsdoc": "off",
     "semi": [
       "error",
-      "always"
+      "always",
+      {
+        "omitLastInOneLineBlock": true
+      }
     ],
     "semi-spacing": [
       "error",


### PR DESCRIPTION
javascript semicolons can contribute to punctuation clutter, and can be safely omitted in certain cases to clean up the code.  Make the last semicolon optional in one-liner blocks, as in e.g.
```
if (foo) { bar() }
```