### PR TITLE
omit the warning if string templates are not used

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -743,7 +743,7 @@ module.exports = {
     "prefer-reflect": "off",
     "prefer-rest-params": "error",
     "prefer-spread": "error",
-    "prefer-template": "warn",
+    "prefer-template": "off",
     "require-yield": "error",
     "rest-spread-spacing": [
       "error",


### PR DESCRIPTION
omit the warning if strings are concatenated.  Sometimes template literals are preferable to string concatenation, but eslint can not judge which is better when, so the linting output gets cluttered with spurious warnings.  Human code review is a better place to correct this type of usage.

An example of where concatenation produces easier to read code:
```
word = root + suffix;
```