### PR TITLE
require parens around arrow function params

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -672,8 +672,8 @@ module.exports = {
       "as-needed"
     ],
     "arrow-parens": [
-      "error",
-      "as-needed",
+      "warn",
+      "always",
       {
         "requireForBlockBody": true
       }


### PR DESCRIPTION
Require parens around arrow function parameters, but tolerate if missing (to not break existing code).

Always parenthesizing the parameter list, even if just one, helps visually reinforce the distinction between arrow functions and other miscellaneous punctuation (eg comparisons <= and >=). It also keeps arrow function definitions consistent, since the parentheses cannot be omitted if there are two or more function parameters.

This change will allow all arrow functions to be defined in a consistent way, e.g.
```
  () => 1
  (a) => 2
  (a, b) => 3
```
where the second function is currently rejected as erroneous usage.