### PR TITLE
allow continue statements

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -436,7 +436,7 @@ module.exports = {
     ],
     "no-array-constructor": "error",
     "no-bitwise": "error",
-    "no-continue": "error",
+    "no-continue": "off",
     "no-inline-comments": "off",
     "no-lonely-if": "error",
     "no-mixed-operators": [


### PR DESCRIPTION
it's self-contradictory to disallow `continue` statements but allow `break` and mid-function `return`, they're all similar unstructured transfers of control meaning "I'm done here, on to the next":  `break` jumps to the bottom of the loop, `continue` jumps to the top.  Used as such it is perfectly clear and easy to follow.