### PR TITLE
allow else-return statements

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -48,7 +48,7 @@ module.exports = {
     "no-caller": "error",
     "no-case-declarations": "error",
     "no-div-regex": "off",
-    "no-else-return": "error",
+    "no-else-return": "off",
     "no-empty-function": [
       "error",
       {


### PR DESCRIPTION
This rule is counter-productive, as disallowing else-return statements can produce harder to follow code; it entangles two otherwise unrelated code paths.  The if-elseif-else pattern clearly delineates the decision tree being evaluated, and using the if-else layout more closely reflects the cognitive structure.  Yes it's trivial to work around, even while maintaining the structured if-elseif-else pattern, but linting rules should make good code easier, not more complicated.