### PR TITLE
allow for-in and for-of loops without warning

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -496,8 +496,6 @@ module.exports = {
     "no-plusplus": "off",
     "no-restricted-syntax": [
       "warn",
-      "ForInStatement",
-      "ForOfStatement",
       "LabeledStatement",
       "WithStatement"
     ],


### PR DESCRIPTION
`for-in` and `for-of` are the go-to native javascript object and array iterators, and do not merit a warning; allow them.