### PR TITLE
do not warn about for-in usage

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -43,7 +43,7 @@ module.exports = {
       "warn",
       "allow-null"
     ],
-    "guard-for-in": "warn",
+    "guard-for-in": "off",
     "no-alert": "warn",
     "no-caller": "error",
     "no-case-declarations": "error",


### PR DESCRIPTION
do not generate warnings for for-in loops that do not filter the key.  Most traversals of properties are on hashes that have no inherited properties, and having to add lines of code to silence the mostly pointless warnings just adds code clutter.

This bit of hand-holding seems related to the quirky javascript OO view that inherited properties are not true properties the same as own properties (likely due to JS functions being first-class values but inherited methods not being easily distinguishable from own methods, and inherited methods arguably not belonging in an enumeration or traversal).