### PR TITLE
allow pathname concatenation

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -243,7 +243,7 @@ module.exports = {
       false
     ],
     "no-new-require": "error",
-    "no-path-concat": "error",
+    "no-path-concat": "off",
     "no-process-env": "off",
     "no-process-exit": "off",
     "no-restricted-modules": "off",


### PR DESCRIPTION
Allow the construction of file paths by concatenation with __dirname or __filename.

This half-hearted rule only prevents the most direct path construction (concatenating to __dirname and __filename), but does not detect less obvious but equally unportable constructs (`filepath = path.concat(__dirname, '\\winfile.js')`), and rejects perfectly portable forms of path concatenation (`filepath = __dirname + path.sep + 'file.js'`).

Also, this rule is really targets code written on Windows to let it run on Unix; the Windows libraries used to handle Unix pathnames containing '/' forward-slash separators correctly.