### PR TITLE
make explicit that no-return-assign allows parenthesized assignment

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -136,7 +136,10 @@ module.exports = {
         "message": "Use the exponentiation operator (**) instead."
       }
     ],
-    "no-return-assign": "warn",
+    "no-return-assign": [
+      "warn",
+      "except-parens"
+    ],
     "no-script-url": "error",
     "no-self-assign": "error",
     "no-self-compare": "error",


### PR DESCRIPTION
eslint v4.7.2 `no-return-assign` permits assignment if parenthesized, eg `return (a = 1)`.  Make this explicit in the ruleset.