### PR TITLE
do not mandate self-updating operators

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -550,7 +550,7 @@ module.exports = {
       "always"
     ],
     "operator-assignment": [
-      "error",
+      "off",
       "always"
     ],
     "operator-linebreak": "off",


### PR DESCRIPTION
The use of self-updating operators `+=, *=` etc should be instinctive, but are too minor to mandate, and should be left to each coder.  There is nothing wrong or confusing about `count = count + 1;`