### PR TITLE
allow assignment in conditionals when parenthesized

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -190,7 +190,7 @@ module.exports = {
     ],
     "no-cond-assign": [
       "error",
-      "always"
+      "except-parens"
     ],
     "no-console": "warn",
     "no-constant-condition": "warn",


### PR DESCRIPTION
permit assignment in conditionals if parenthesized to indicate that it's intentional.

Combining the assignment and test can result in simpler code, e.g.
```
    while ((nextGuess = numbers[guessIndex++]) !== 42) wrongGuessCount += 1;
```
vs
```
    nextGuess = numbers[guessIndex++];
    while (nextGuess !== 42) {
        wrongGuessCount += 1;
        nextGuess = numbers[guessIndex++];
    }
```