### PR TITLE
allow combined let declarations

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -547,7 +547,7 @@ module.exports = {
     ],
     "one-var-declaration-per-line": [
       "error",
-      "always"
+      "initializations"
     ],
     "operator-assignment": [
       "error",

--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -542,7 +542,7 @@ module.exports = {
       }
     ],
     "one-var": [
-      "error",
+      "off",
       "never"
     ],
     "one-var-declaration-per-line": [


### PR DESCRIPTION
Turn off `one-var` to permit variable declarations to be combined into a single line.  This rule was primarily useful in the positive sense to mandate that all variables be declared together at the top of the function, but is clumsy in the negative sense (it disallows any combined var declarations), and is not really useful with block-specific `const` and `let` semantics.

Also change `one-var-declaration-per-line` to only require separate lines for vars with initializers, to allow combined `let` declarations of unitialized vars.

```
    let head, tail, current;      // clean intuitive form
```
vs
```
    let head;                     // mandated redundant form
    let tail;
    let current;
```