### PR TITLE
allow chained ternary expressions

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -491,7 +491,7 @@ module.exports = {
       }
     ],
     "no-negated-condition": "off",
-    "no-nested-ternary": "error",
+    "no-nested-ternary": "off",
     "no-new-object": "error",
     "no-plusplus": "off",
     "no-restricted-syntax": [


### PR DESCRIPTION
permit chained ternary if-elseif-elseeif-else expressions.  The rule `no-nested-ternary` is misnamed, because the javascript ternary operator semantics are chaining (same as C), not nesting (like PHP).  The operator itself is clear and easy to understand, though admittedly it can be helped by good formatting.  E.g., to 0-pad numbers to 4 digits:
```
    print(
        n >= 1000 ? '' + n :
        n >= 100  ? '0' + n :
        n >= 10   ? '00' + n :
                    '000' + n
    )
```