### PR TITLE
allow ternary expressions even when other forms are possible

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -512,7 +512,7 @@ module.exports = {
       }
     ],
     "no-unneeded-ternary": [
-      "error",
+      "off",
       {
         "defaultAssignment": false
       }


### PR DESCRIPTION
Allow using ternary expressions to assign a boolean value.  Ternary expressions are a more direct, clear and obvious way of expressing intent than relying on obscure syntax tricks and javascript short-circuit boolean semantics.

Yes every ternary expression can be converted into a form using just `||` and `&&`, but not for the better.  Consider `haveMore = peekHead() ? true : false;` vs `haveMore = (peekHead() && true) || false;`.