### PR TITLE
allow bracket notation for hash properties

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -30,7 +30,7 @@ module.exports = {
       }
     ],
     "dot-notation": [
-      "error",
+      "off",
       {
         "allowKeywords": true
       }


### PR DESCRIPTION
Turn off the `dot-notation` rule that's intrusive and offers little benefit.  Some hashes are more logically accessed as arrays, not objects, eg `req.headers`, especially when adjacent lines necessarily have to use bracket notation.
```
    req.headers['Content-Type'] = 'application/json';         // permitted
    req.headers['Authorization'] = 'Basic';                   // banned
```