### PR TITLE
allow bitwise operators

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -435,7 +435,13 @@ module.exports = {
       }
     ],
     "no-array-constructor": "error",
-    "no-bitwise": "off",
+    "no-bitwise": [
+      "off",
+      {
+        "allow": ["^", "~", "&", "|", "<<", ">>", ">>>", "^=", "&=", "|=", "<<=", ">>=", ">>>="],
+        "int32Hint": true
+      }
+    ],
     "no-continue": "error",
     "no-inline-comments": "off",
     "no-lonely-if": "error",

--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -435,7 +435,7 @@ module.exports = {
       }
     ],
     "no-array-constructor": "error",
-    "no-bitwise": "error",
+    "no-bitwise": "off",
     "no-continue": "error",
     "no-inline-comments": "off",
     "no-lonely-if": "error",


### PR DESCRIPTION
Permit the use of bitwise operators.  This over-zealous rule bans `~, ^, &, |, ^=, &=, |=, <<, >>, >>>, <<=, >>=, >>>=` because the occurrence of `&` and `|` might be inadvertent typos.  While it may be true that bitwise operators don't see much use in browsers, on the backend they're quite useful; they strength reduce int32 and byte operations, and they have useful semantics (truncation, unsigned int ops, sign extension, etc).