### PR TITLE
Enable JSX file support

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -865,6 +865,7 @@ module.exports = {
       "node": {
         "extensions": [
           ".js",
+          ".jsx",
           ".json"
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@progresskinvey/eslint-config-kinvey-platform",
   "license": "Apache-2.0",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "ESLint Profile for the Kinvey Platform",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
The `import/extensions` rule was failing to detect `.jsx` files and always want to specify the file extension when importing even that the `.jsx` is marked as `never`.

The plugin should know how to handle `.jsx` files.