### PR TITLE
Rollback max-len to 150

### DIFF
--- a/kinvey-rules.js
+++ b/kinvey-rules.js
@@ -382,7 +382,7 @@ module.exports = {
     ],
     "max-len": [
       "warn",
-      200,
+      150,
       4
     ],
     "max-lines": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@progresskinvey/eslint-config-kinvey-platform",
   "license": "Apache-2.0",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "ESLint Profile for the Kinvey Platform",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Github displays the code in a limited space. When the line length is more than ~150 symbols the code reviews become harder, because part of the code is not visible on the screen.
![Screenshot 2022-02-09 at 14 07 22](https://user-images.githubusercontent.com/3524687/153198047-12722b97-85a7-4960-9f07-973bcb785885.png)
